### PR TITLE
Fixed looking for jwt token in headers or cookies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,9 @@ const verifyAndDecodeToken = ({ context }) => {
 
   if (
     !req ||
-    !req.headers ||
-    (!req.headers.authorization && !req.headers.Authorization) ||
-    (!req && !req.cookies && !req.cookies.token)
+    ((!req.headers ||
+      (!req.headers.authorization && !req.headers.Authorization)) &&
+      (!req.cookies || !req.cookies.token))
   ) {
     throw new AuthorizationError({ message: "No authorization token." });
   }


### PR DESCRIPTION
Fixes "No authorization token." when no headers found even if token cookie is defined. #3 